### PR TITLE
moved wiki delete by entry from /wiki to /wiki/{wikiEntryId}

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -674,6 +674,20 @@ paths:
           description: Unauthorized
         '500':
           description: Internal Server Error
+    delete:
+      summary: Delete wiki entry by id.
+      operationId: delete-wiki
+      responses:
+        '200':
+          description: OK
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal Server Error
+      description: Delete wiki entry by id.
+      tags:
+        - wiki-service
+        - admin
   /wiki:
     get:
       summary: Get all wiki entries
@@ -720,22 +734,6 @@ paths:
       tags:
         - wiki-service
         - admin
-    delete:
-      summary: Delete wiki entry by id.
-      operationId: delete-wiki
-      responses:
-        '200':
-          description: OK
-        '401':
-          description: Unauthorized
-        '500':
-          description: Internal Server Error
-      description: Delete wiki entry by id.
-      tags:
-        - wiki-service
-        - admin
-    parameters:
-      - $ref: '#/components/parameters/wikiEntryId'
 components:
   securitySchemes:
     JWTAuth:


### PR DESCRIPTION
The delete function should not have been in /wiki but in /wiki/{wikiEntryId} and also the parameters for it were indented wrongly which required a get and post request on /wiki to also provide a wiki entry id.