### PR TITLE
Feature: Use admin routes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -91,7 +91,7 @@ paths:
           description: OK
         '500':
           description: Internal Service Error
-  /users:
+  /users/admin:
     post:
       summary: Create user.
       operationId: post-user
@@ -113,7 +113,6 @@ paths:
               $ref: '#/components/schemas/user'
       tags:
         - user-service
-        - admin
       description: Create a user.
     get:
       summary: Get all users.
@@ -133,11 +132,8 @@ paths:
           description: Internal Server Error
       tags:
         - user-service
-        - admin
       description: Get all users.
-  '/users/{userId}':
-    parameters:
-      - $ref: '#/components/parameters/userId'
+  /user:
     get:
       summary: Read user by id.
       tags:
@@ -194,9 +190,14 @@ paths:
       tags:
         - user-service
       description: Delete user by id.
-  '/users/{userId}/settings':
+  '/user/settings':
     parameters:
-      - $ref: '#/components/parameters/userId'
+      - in: header
+        name: X-userId
+        schema:
+          type: string
+          format: uuid
+        required: true
     get:
       summary: Get user's settings.
       tags:
@@ -262,13 +263,6 @@ paths:
         - mood-diary-service
       operationId: get-diary
       description: Get mood diary by userId. UserId is injected by oathkeeper
-      parameters:
-        - in: header
-          name: X-userId
-          schema:
-            type: string
-            format: uuid
-          required: true
       responses:
         '200':
           description: OK
@@ -329,7 +323,7 @@ paths:
       description: Delete mood from user's diary.
       tags:
         - mood-diary-service
-  /safetyNet:
+  /safetyNet/admin:
     get:
       summary: Get safety nets of all users.
       tags:
@@ -349,13 +343,7 @@ paths:
           description: Internal Server Error
       operationId: get-safetyNet
       description: Get safety nets of all users - without identifying the users individually.
-  '/safetyNet/{userId}':
-    parameters:
-      - name: userId
-        in: path
-        required: true
-        schema:
-          type: integer
+  /safetyNet:
     get:
       summary: Get safety net by userId.
       tags:
@@ -408,7 +396,7 @@ paths:
       description: Delete safetyNet item by timestamp.
       tags:
         - motivator-service
-  /motivator:
+  /motivator/admin:
     parameters: []
     get:
       summary: Get all motivators.
@@ -456,9 +444,7 @@ paths:
       description: Delete a motivator by id.
       tags:
         - motivator-service
-  '/motivator/{userId}':
-    parameters:
-      - $ref: '#/components/parameters/userId'
+  '/motivator':
     get:
       summary: Get current motivators by userId.
       tags:
@@ -513,9 +499,8 @@ paths:
       description: Delete a motivator from user's motivators.
       tags:
         - motivator-service
-  '/motivator/{userId}/result/{motivatorId}':
+  '/motivator/result/{motivatorId}':
     parameters:
-      - $ref: '#/components/parameters/userId'
       - $ref: '#/components/parameters/motivatorId'
     post:
       summary: Add a new result to user's current motivator.
@@ -677,6 +662,7 @@ paths:
           description: Internal Server Error
       operationId: get-wiki
       description: Get all wiki entries.
+  /wiki/admin:
     post:
       summary: Add new wiki entries
       operationId: post-wiki
@@ -702,7 +688,6 @@ paths:
       x-tira: false
       tags:
         - wiki-service
-        - admin
     delete:
       summary: Delete wiki entry by id.
       operationId: delete-wiki
@@ -716,7 +701,6 @@ paths:
       description: Delete wiki entry by id.
       tags:
         - wiki-service
-        - admin
 components:
   securitySchemes:
     JWTAuth:
@@ -1626,12 +1610,6 @@ components:
       required: true
       schema:
         type: string
-    userId:
-      name: userId
-      in: path
-      required: true
-      schema:
-        type: integer
     motivatorId:
       name: motivatorId
       in: path

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -255,13 +255,20 @@ paths:
                 $ref: '#/components/schemas/setting'
       tags:
         - user-service
-  '/diary/{userId}':
+  '/diary':
     get:
       summary: Get mood diary by userId.
       tags:
         - mood-diary-service
       operationId: get-diary
-      description: Get mood diary by userId.
+      description: Get mood diary by userId. UserId is injected by oathkeeper
+      parameters:
+        - in: header
+          name: X-userId
+          schema:
+            type: string
+            format: uuid
+          required: true
       responses:
         '200':
           description: OK
@@ -276,11 +283,16 @@ paths:
         '500':
           description: Internal Server Error
       x-tira: true
-    parameters:
-      - $ref: '#/components/parameters/userId'
     post:
       summary: Add mood to diary
       operationId: post-diary-userId
+      parameters:
+        - in: header
+          name: X-userId
+          schema:
+            type: string
+            format: uuid
+          required: true
       responses:
         '200':
           description: OK
@@ -300,6 +312,13 @@ paths:
     delete:
       summary: Delete mood from user's diary.
       operationId: deleteuser-userId-diary
+      parameters:
+        - in: header
+          name: X-userId
+          schema:
+            type: string
+            format: uuid
+          required: true
       responses:
         '200':
           description: OK

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -273,13 +273,6 @@ paths:
     post:
       summary: Add mood to diary
       operationId: post-diary-userId
-      parameters:
-        - in: header
-          name: X-userId
-          schema:
-            type: string
-            format: uuid
-          required: true
       responses:
         '200':
           description: OK

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -753,8 +753,6 @@ paths:
       tags:
         - wiki-service
         - admin
-    parameters:
-      - $ref: '#/components/parameters/wikiEntryId'
 components:
   securitySchemes:
     JWTAuth:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -327,16 +327,6 @@ paths:
         '500':
           description: Internal Server Error
       description: Delete mood from user's diary.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/timestamp'
-          application/xml:
-            schema:
-              type: object
-              properties: {}
-        description: ''
       tags:
         - mood-diary-service
   /safetyNet:
@@ -416,12 +406,6 @@ paths:
         '500':
           description: Internal Server Error
       description: Delete safetyNet item by timestamp.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-              format: date-time
       tags:
         - motivator-service
   /motivator:
@@ -470,11 +454,6 @@ paths:
         '500':
           description: Internal Server Error
       description: Delete a motivator by id.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/motivatorId'
       tags:
         - motivator-service
   '/motivator/{userId}':
@@ -531,11 +510,6 @@ paths:
           description: Unauthorized
         '500':
           description: Internal Server Error
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/motivatorId'
       description: Delete a motivator from user's motivators.
       tags:
         - motivator-service
@@ -568,11 +542,6 @@ paths:
         '200':
           description: OK
       description: Delete result from user's current motivator by timestamp.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/timestamp'
       tags:
         - motivator-service
   '/notification/{userId}':
@@ -628,11 +597,6 @@ paths:
           description: Unauthorized
         '500':
           description: Internal Server Error
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/notificationId'
       description: Delete notification for user by id.
       tags:
         - notification-service

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -292,13 +292,6 @@ paths:
     delete:
       summary: Delete mood from user's diary.
       operationId: deleteuser-userId-diary
-      parameters:
-        - in: header
-          name: X-userId
-          schema:
-            type: string
-            format: uuid
-          required: true
       responses:
         '200':
           description: OK

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -78,7 +78,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/login-with-flow-id-request'
-            exmaple:
+            example:
               identifier: "<accountKey>"
               csrf_token: "<token>"
               password: "md5(<accountKey>)"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -191,13 +191,6 @@ paths:
         - user-service
       description: Delete user by id.
   '/user/settings':
-    parameters:
-      - in: header
-        name: X-userId
-        schema:
-          type: string
-          format: uuid
-        required: true
     get:
       summary: Get user's settings.
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -91,7 +91,7 @@ paths:
           description: OK
         '500':
           description: Internal Service Error
-  /user:
+  /users:
     post:
       summary: Create user.
       operationId: post-user
@@ -135,7 +135,7 @@ paths:
         - user-service
         - admin
       description: Get all users.
-  '/user/{userId}':
+  '/users/{userId}':
     parameters:
       - $ref: '#/components/parameters/userId'
     get:
@@ -194,7 +194,7 @@ paths:
       tags:
         - user-service
       description: Delete user by id.
-  '/user/{userId}/settings':
+  '/users/{userId}/settings':
     parameters:
       - $ref: '#/components/parameters/userId'
     get:
@@ -219,7 +219,7 @@ paths:
       operationId: get-user-settings
       description: Get user's settings.
     delete:
-      summary: Delete user by id.
+      summary: Delete user setting by id.
       operationId: delete-user-settings
       responses:
         '200':


### PR DESCRIPTION
Addresses mindtastic/user-service#46

Routes don't need to include userID as a parameter. Oathkeeper injects service-specific userIDs into the header.
I removed the requestBody for delete routes bc OpenApi 3.0 complains about it and we want to auto-generate code from the API spec.
