### PR TITLE
Modular API Spec and service URLs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,88 +1,47 @@
 openapi: 3.0.3
 info:
   title: Kopfsachen
-  version: '0.1'
+  version: '0.2'
   description: Kopfsachen e. V. is an association for the promotion of young people's mental health. The goal is to teach the basics of mental health literacy in various educational formats.
   contact:
     name: Kopfsachen e. V.
     email: mail@kopfsachen.org
     url: 'https://www.kopfsachen.org'
 paths:
-  '/self-service/registration/api':
-    get:
-      summary: Initate registration flow
-      tags:
-        - authentication
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/registration'
-        '500':
-          description: Internal Server Error
-  '/self-service/registration':
-    post:
-      parameters:
-        - $ref: '#/components/parameters/flow'
-      summary: Receive accountKey during registration
-      tags:
-        - authentication
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/registration-with-flow-id-response'
-        '500':
-          description: Internal Service Error
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/registration-with-flow-id-request'
-  '/self-service/login/api':
-    get:
-      tags:
-        - authentication
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/registration'
-        '500':
-          description: Internal Service Error
-  '/self-service/login':
-    post:
-      parameters:
-        - $ref: '#/components/parameters/flow'
-      tags:
-        - authentication
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/session'
-              example:
-                session_token: "2wBPKcSG0KxSxDBrgJA8ackTwBIea9y5"
-        '500':
-          description: Internal Service Error
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/login-with-flow-id-request'
-            exmaple:
-              identifier: "<accountKey>"
-              csrf_token: "<token>"
-              password: "md5(<accountKey>)"
-  '/self-service/logout':
+  /self-service/registration/api:
+    $ref: '/specs/registration.yaml#/registrationApiInit'
+  /self-service/registration:
+    $ref: '/specs/registration.yaml#/registrationSubmit'
+  /self-service/login/api:
+    $ref: '/specs/authentication.yaml#/loginApiInit'
+  /self-service/login:
+    $ref: '/specs/authentication.yaml#/loginSubmit'
+  #   post:
+  #     parameters:
+  #       - $ref: '#/components/parameters/flow'
+  #     tags:
+  #       - authentication
+  #     responses:
+  #       '200':
+  #         description: OK
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: '#/components/schemas/session'
+  #             example:
+  #               session_token: 2wBPKcSG0KxSxDBrgJA8ackTwBIea9y5
+  #       '500':
+  #         description: Internal Service Error
+  #     requestBody:
+  #       content:
+  #         application/json:
+  #           schema:
+  #             $ref: '#/components/schemas/login-with-flow-id-request'
+  #           example:
+  #             identifier: <accountKey>
+  #             csrf_token: <token>
+  #             password: md5(<accountKey>)
+  /self-service/logout:
     delete:
       tags:
         - authentication
@@ -693,7 +652,8 @@ paths:
         '500':
           description: Internal Server Error
       operationId: get-wiki
-      description: Get all wiki entries.
+      description: Get all wiki entries.     
+  /wiki/admin:
     post:
       summary: Add new wiki entries
       operationId: post-wiki
@@ -747,57 +707,16 @@ components:
         > Authorization: Bearer <token>
       x-last-modified: 1646648515924
   schemas:
-    registration:
-      description: Registration initialization
-      type: object
-      x-examples:
-        example-1:
-          flow: "231125d7-11d5-4e0f-80e9-5081003ae8ca"
-      properties:
-        id:
-          type: string
-          format: uuid
-          minLength: 36
-          maxLength: 36
-    registration-with-flow-id-request:
-      description: Registration with FlowID
-      type: object
-      properties:
-        method:
-          type: string
-          pattern: "password"
-    registration-with-flow-id-response:
-      description: Registration with FlowID
-      type: object
-      properties:
-        accountKey:
-          type: string
-          format: uuid
-          minLength: 36
-          maxLength: 36
-    login-with-flow-id-request:
-      description: Login with FlowID
-      type: object
-      properties:
-        method:
-          type: string
-          pattern: "password"
-        identifier:
-          type: string
-        csrf_token:
-          type: string
-        password:
-          type: string
     user:
       description: A user object
       type: object
       x-examples:
         example-1:
-          user_id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          user_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
           username: maja
           role: user
         example-2:
-          user_id: "123e4567-e89b-12d3-a456-426655440000"
+          user_id: 123e4567-e89b-12d3-a456-426655440000
           username: string
           role: admin
       x-tira: true
@@ -831,17 +750,9 @@ components:
       x-examples:
         example-1:
           id: 42
-          user_id: "705e4dcb-3ecd-24f3-3a35-3e926e4bded5"
+          user_id: 705e4dcb-3ecd-24f3-3a35-3e926e4bded5
           username: string
           role: admin
-    session:
-      title: session-object
-      type: object
-      properties:
-        session_token:
-          type: string
-        session:
-          type: object
     tilt:
       description: 'A valid tilt document validates against the tilt schema: https://github.com/Transparency-Information-Language/schema/blob/master/tilt-schema.json'
       type: object
@@ -1639,18 +1550,6 @@ components:
   headers: {}
   responses: {}
   parameters:
-    flow:
-      name: flow
-      in: query
-      required: true
-      schema:
-        type: string
-    userId:
-      name: userId
-      in: path
-      required: true
-      schema:
-        type: integer
     motivatorId:
       name: motivatorId
       in: path
@@ -1673,12 +1572,18 @@ tags:
   - name: administration-service
   - name: tilt-service
   - name: authentication
+    description: 'The authentication API is based on the ORY Kratos HTTP API, but with some additional tweaks. See [Kratos Docs](https://www.ory.sh/docs/kratos/reference/api) and [Mindtastic Docs](github.com/mindtastic/bouncer/wiki) for more information.'
 servers:
-  - url: 'https://api.implementation.online'
-    description: ''
-    variables: {}
-  - url: 'http://localhost'
-    description: ''
-    variables: {}
-#security:
-#  - JWTAuth: []
+  - url: 'https://{service}.api.{environment}.mindtastic.lol'
+    description: Development API for testing purposes
+    variables:
+      service:
+        default: echo
+        description: The requests gets routed to the individual microservice by pattern matching the requests Host header
+      environment:
+        enum:
+          - live
+          - stage
+          - dev
+        default: live
+        description: Choose the environment to work on.

--- a/schemas/authentication.yaml
+++ b/schemas/authentication.yaml
@@ -1,0 +1,21 @@
+session:
+  title: Kratos API Session
+  type: object
+  properties:
+    session_token:
+      type: string
+    session:
+      type: object
+  example:
+    session_token: 2wBPKcSG0KxSxDBrgJA8ackTwBIea9y5
+
+flow:
+  name: flow
+  in: query
+  explode: true
+  required: true
+  schema:
+    type: string
+  description: The Login flow ID as an URL Query parameters
+
+    

--- a/schemas/kratos_t.yaml
+++ b/schemas/kratos_t.yaml
@@ -1,0 +1,717 @@
+UUID:
+  format: uuid4
+  type: string
+
+selfServiceRegistrationFlow:
+  example:
+    expires_at: 2000-01-23T04:56:07.000Z
+    ui:
+      nodes:
+        - meta:
+            label:
+              context: '{}'
+              id: 0
+              text: text
+              type: type
+          messages:
+            - context: '{}'
+              id: 0
+              text: text
+              type: type
+            - context: '{}'
+              id: 0
+              text: text
+              type: type
+          type: text
+          group: default
+        - meta:
+            label:
+              context: '{}'
+              id: 0
+              text: text
+              type: type
+          messages:
+            - context: '{}'
+              id: 0
+              text: text
+              type: type
+            - context: '{}'
+              id: 0
+              text: text
+              type: type
+          type: text
+          group: default
+      method: method
+      action: action
+      messages:
+        - context: '{}'
+          id: 0
+          text: text
+          type: type
+        - context: '{}'
+          id: 0
+          text: text
+          type: type
+    return_to: return_to
+    type: type
+    issued_at: 2000-01-23T04:56:07.000Z
+    request_url: request_url
+  properties:
+    active:
+      $ref: '#/identityCredentialsType'
+    expires_at:
+      description: >-
+        ExpiresAt is the time (UTC) when the flow expires. If the user still
+        wishes to log in,
+
+        a new flow has to be initiated.
+      format: date-time
+      type: string
+    id:
+      $ref: '#/UUID'
+    issued_at:
+      description: IssuedAt is the time (UTC) when the flow occurred.
+      format: date-time
+      type: string
+    request_url:
+      description: >-
+        RequestURL is the initial URL that was requested from Ory Kratos. It can
+        be used
+
+        to forward information contained in the URL's path or query for example.
+      type: string
+    return_to:
+      description: ReturnTo contains the requested return_to URL.
+      type: string
+    type:
+      description: The flow type can either be `api` or `browser`.
+      title: Type is the flow type.
+      type: string
+    ui:
+      $ref: '#/uiContainer'
+  required:
+    - expires_at
+    - id
+    - issued_at
+    - request_url
+    - type
+    - ui
+  type: object
+
+selfServiceLoginFlow:
+  description: >-
+    This object represents a login flow. A login flow is initiated at the
+    "Initiate Login API / Browser Flow"
+  example:
+    expires_at: 2000-01-23T04:56:07.000Z
+    ui:
+      nodes:
+        - meta:
+            label:
+              context: '{}'
+              id: 0
+              text: text
+              type: type
+          messages:
+            - context: '{}'
+              id: 0
+              text: text
+              type: type
+            - context: '{}'
+              id: 0
+              text: text
+              type: type
+          type: text
+          group: default
+        - meta:
+            label:
+              context: '{}'
+              id: 0
+              text: text
+              type: type
+          messages:
+            - context: '{}'
+              id: 0
+              text: text
+              type: type
+            - context: '{}'
+              id: 0
+              text: text
+              type: type
+          type: text
+          group: default
+      method: method
+      action: action
+      messages:
+        - context: '{}'
+          id: 0
+          text: text
+          type: type
+        - context: '{}'
+          id: 0
+          text: text
+          type: type
+    updated_at: 2000-01-23T04:56:07.000Z
+    created_at: 2000-01-23T04:56:07.000Z
+    refresh: true
+    return_to: return_to
+    type: type
+    issued_at: 2000-01-23T04:56:07.000Z
+    request_url: request_url
+  properties:
+    active:
+      $ref: '#/identityCredentialsType'
+    created_at:
+      description: CreatedAt is a helper struct field for gobuffalo.pop.
+      format: date-time
+      type: string
+    expires_at:
+      description: >-
+        ExpiresAt is the time (UTC) when the flow expires. If the user still
+        wishes to log in,
+
+        a new flow has to be initiated.
+      format: date-time
+      type: string
+    id:
+      $ref: '#/UUID'
+    issued_at:
+      description: IssuedAt is the time (UTC) when the flow started.
+      format: date-time
+      type: string
+    refresh:
+      description: Refresh stores whether this login flow should enforce re-authentication.
+      type: boolean
+    request_url:
+      description: >-
+        RequestURL is the initial URL that was requested from Ory Kratos. It can
+        be used
+
+        to forward information contained in the URL's path or query for example.
+      type: string
+    return_to:
+      description: ReturnTo contains the requested return_to URL.
+      type: string
+    type:
+      description: The flow type can either be `api` or `browser`.
+      title: Type is the flow type.
+      type: string
+    ui:
+      $ref: '#/uiContainer'
+    updated_at:
+      description: UpdatedAt is a helper struct field for gobuffalo.pop.
+      format: date-time
+      type: string
+  required:
+    - expires_at
+    - id
+    - issued_at
+    - request_url
+    - type
+    - ui
+  title: Login Flow
+  type: object
+
+# KRATOS DEPENDENCIES
+
+uiContainer:
+  description: >-
+    Container represents a HTML Form. The container can work with both HTTP Form
+    and JSON requests
+  example:
+    nodes:
+      - meta:
+          label:
+            context: '{}'
+            id: 0
+            text: text
+            type: type
+        messages:
+          - context: '{}'
+            id: 0
+            text: text
+            type: type
+          - context: '{}'
+            id: 0
+            text: text
+            type: type
+        type: text
+        group: default
+      - meta:
+          label:
+            context: '{}'
+            id: 0
+            text: text
+            type: type
+        messages:
+          - context: '{}'
+            id: 0
+            text: text
+            type: type
+          - context: '{}'
+            id: 0
+            text: text
+            type: type
+        type: text
+        group: default
+    method: method
+    action: action
+    messages:
+      - context: '{}'
+        id: 0
+        text: text
+        type: type
+      - context: '{}'
+        id: 0
+        text: text
+        type: type
+  properties:
+    action:
+      description: >-
+        Action should be used as the form action URL `<form action="{{ .Action
+        }}" method="post">`.
+      type: string
+    messages:
+      items:
+        $ref: '#/uiText'
+      type: array
+    method:
+      description: Method is the form method (e.g. POST)
+      type: string
+    nodes:
+      items:
+        $ref: '#/uiNode'
+      type: array
+  required:
+    - action
+    - method
+    - nodes
+  type: object
+
+identityCredentialsType:
+  description: and so on.
+  enum:
+    - password
+    - totp
+    - oidc
+    - webauthn
+    - lookup_secret
+  title: >-
+    CredentialsType  represents several different credential types, like
+    password credentials, passwordless credentials,
+  type: string
+
+uiText:
+  example:
+    context: '{}'
+    id: 0
+    text: text
+    type: type
+  properties:
+    context:
+      description: The message's context. Useful when customizing messages.
+      type: object
+    id:
+      format: int64
+      type: integer
+    text:
+      description: The message text. Written in american english.
+      type: string
+    type:
+      type: string
+  required:
+    - id
+    - text
+    - type
+  type: object
+
+uiNode:
+  description: >-
+    Nodes are represented as HTML elements or their native UI equivalents. For
+    example,
+
+    a node can be an `<img>` tag, or an `<input element>` but also `some plain
+    text`.
+  example:
+    meta:
+      label:
+        context: '{}'
+        id: 0
+        text: text
+        type: type
+    messages:
+      - context: '{}'
+        id: 0
+        text: text
+        type: type
+      - context: '{}'
+        id: 0
+        text: text
+        type: type
+    type: text
+    group: default
+  properties:
+    attributes:
+      $ref: '#/uiNodeAttributes'
+    group:
+      description: >-
+        Group specifies which group (e.g. password authenticator) this node
+        belongs to.
+      enum:
+        - default
+        - password
+        - oidc
+        - profile
+        - link
+        - totp
+        - lookup_secret
+        - webauthn
+      type: string
+    messages:
+      items:
+        $ref: '#/uiText'
+      type: array
+    meta:
+      $ref: '#/uiNodeMeta'
+    type:
+      description: The node's type
+      enum:
+        - text
+        - input
+        - img
+        - a
+        - script
+      type: string
+  required:
+    - attributes
+    - group
+    - messages
+    - meta
+    - type
+  title: Node represents a flow's nodes
+  type: object
+
+uiNodeMeta:
+  description: |-
+    This might include a label and other information that can optionally
+    be used to render UIs.
+  example:
+    label:
+      context: '{}'
+      id: 0
+      text: text
+      type: type
+  properties:
+    label:
+      $ref: '#/uiText'
+  title: A Node's Meta Information
+  type: object
+
+uiNodeAttributes:
+  discriminator:
+    mapping:
+      a: '#/uiNodeAnchorAttributes'
+      img: '#/uiNodeImageAttributes'
+      input: '#/uiNodeInputAttributes'
+      script: '#/uiNodeScriptAttributes'
+      text: '#/uiNodeTextAttributes'
+    propertyName: node_type
+  oneOf:
+    - $ref: '#/uiNodeInputAttributes'
+    - $ref: '#/uiNodeTextAttributes'
+    - $ref: '#/uiNodeImageAttributes'
+    - $ref: '#/uiNodeAnchorAttributes'
+    - $ref: '#/uiNodeScriptAttributes'
+  title: Attributes represents a list of attributes (e.g. `href="foo"` for links).
+
+uiNodeInputAttributes:
+  description: InputAttributes represents the attributes of an input node
+  properties:
+    disabled:
+      description: Sets the input's disabled field to true or false.
+      type: boolean
+    label:
+      $ref: '#/uiText'
+    name:
+      description: The input's element name.
+      type: string
+    node_type:
+      description: >-
+        NodeType represents this node's types. It is a mirror of `node.type` and
+
+        is primarily used to allow compatibility with OpenAPI 3.0.  In this
+        struct it technically always is "input".
+      type: string
+    onclick:
+      description: >-
+        OnClick may contain javascript which should be executed on click. This
+        is primarily
+
+        used for WebAuthn.
+      type: string
+    pattern:
+      description: The input's pattern.
+      type: string
+    required:
+      description: Mark this input field as required.
+      type: boolean
+    type:
+      type: string
+    value:
+      description: The input's value.
+      nullable: true
+  required:
+    - disabled
+    - name
+    - node_type
+    - type
+  type: object
+
+uiNodeTextAttributes:
+  properties:
+    id:
+      description: A unique identifier
+      type: string
+    node_type:
+      description: >-
+        NodeType represents this node's types. It is a mirror of `node.type` and
+
+        is primarily used to allow compatibility with OpenAPI 3.0.  In this
+        struct it technically always is "text".
+      type: string
+    text:
+      $ref: '#/uiText'
+  required:
+    - id
+    - node_type
+    - text
+  title: TextAttributes represents the attributes of a text node.
+  type: object
+
+uiNodeImageAttributes:
+  properties:
+    height:
+      description: Height of the image
+      format: int64
+      type: integer
+    id:
+      description: A unique identifier
+      type: string
+    node_type:
+      description: >-
+        NodeType represents this node's types. It is a mirror of `node.type` and
+
+        is primarily used to allow compatibility with OpenAPI 3.0.  In this
+        struct it technically always is "img".
+      type: string
+    src:
+      description: |-
+        The image's source URL.
+        format: uri
+      type: string
+    width:
+      description: Width of the image
+      format: int64
+      type: integer
+  required:
+    - height
+    - id
+    - node_type
+    - src
+    - width
+  title: ImageAttributes represents the attributes of an image node.
+  type: object
+
+uiNodeAnchorAttributes:
+  properties:
+    href:
+      description: |-
+        The link's href (destination) URL.
+        format: uri
+      type: string
+    id:
+      description: A unique identifier
+      type: string
+    node_type:
+      description: >-
+        NodeType represents this node's types. It is a mirror of `node.type` and
+
+        is primarily used to allow compatibility with OpenAPI 3.0.  In this
+        struct it technically always is "a".
+      type: string
+    title:
+      $ref: '#/uiText'
+  required:
+    - href
+    - id
+    - node_type
+    - title
+  title: AnchorAttributes represents the attributes of an anchor node.
+  type: object
+
+uiNodeScriptAttributes:
+  properties:
+    async:
+      description: The script async type
+      type: boolean
+    crossorigin:
+      description: The script cross origin policy
+      type: string
+    id:
+      description: A unique identifier
+      type: string
+    integrity:
+      description: The script's integrity hash
+      type: string
+    node_type:
+      description: >-
+        NodeType represents this node's types. It is a mirror of `node.type` and
+
+        is primarily used to allow compatibility with OpenAPI 3.0. In this
+        struct it technically always is "script".
+      type: string
+    nonce:
+      description: >-
+        Nonce for CSP
+
+        A nonce you may want to use to improve your Content Security Policy.
+
+        You do not have to use this value but if you want to improve your CSP
+
+        policies you may use it. You can also choose to use your own nonce
+        value!
+      type: string
+    referrerpolicy:
+      description: The script referrer policy
+      type: string
+    src:
+      description: The script source
+      type: string
+    type:
+      description: The script MIME type
+      type: string
+  required:
+    - async
+    - crossorigin
+    - id
+    - integrity
+    - node_type
+    - nonce
+    - referrerpolicy
+    - src
+    - type
+  title: ScriptAttributes represent script nodes which load javascript.
+  type: object
+
+
+# ERRORS
+genericError:
+  properties:
+    code:
+      description: The status code
+      example: 404
+      format: int64
+      type: integer
+    debug:
+      description: |-
+        Debug information
+        This field is often not exposed to protect against leaking
+        sensitive information.
+      example: SQL field "foo" is not a bool.
+      type: string
+    details:
+      additionalProperties: false
+      description: Further error details
+      type: object
+    id:
+      description: |-
+        The error ID
+        Useful when trying to identify various errors in application logic.
+      type: string
+    message:
+      description: |-
+        Error message
+        The error's message.
+      example: The resource could not be found
+      type: string
+    reason:
+      description: A human-readable reason for the error
+      example: User with ID 1234 does not exist.
+      type: string
+    request:
+      description: |-
+        The request ID
+        The request ID is often exposed internally in order to trace
+        errors across service architectures. This is often a UUID.
+      example: d7ef54b1-ec15-46e6-bccb-524b82c035e6
+      type: string
+    status:
+      description: The status description
+      example: Not Found
+      type: string
+  required:
+    - message
+  type: object
+
+jsonError:
+  description: The standard Ory JSON API error format.
+  properties:
+    error:
+      $ref: '#/genericError'
+  required:
+    - error
+  title: Kratos API JSON Error Response
+  type: object
+
+selfServiceBrowserLocationChangeRequiredError:
+  properties:
+    code:
+      description: The status code
+      example: 404
+      format: int64
+      type: integer
+    debug:
+      description: |-
+        Debug information
+        This field is often not exposed to protect against leaking
+        sensitive information.
+      example: SQL field "foo" is not a bool.
+      type: string
+    details:
+      additionalProperties: true
+      description: Further error details
+      type: object
+    id:
+      description: |-
+        The error ID
+        Useful when trying to identify various errors in application logic.
+      type: string
+    message:
+      description: |-
+        Error message
+        The error's message.
+      example: The resource could not be found
+      type: string
+    reason:
+      description: A human-readable reason for the error
+      example: User with ID 1234 does not exist.
+      type: string
+    redirect_browser_to:
+      description: Since when the flow has expired
+      type: string
+    request:
+      description: |-
+        The request ID
+        The request ID is often exposed internally in order to trace
+        errors across service architectures. This is often a UUID.
+      example: d7ef54b1-ec15-46e6-bccb-524b82c035e6
+      type: string
+    status:
+      description: The status description
+      example: Not Found
+      type: string
+  required:
+    - message
+  title: Is sent when a flow requires a browser to change its location.
+  type: object
+

--- a/schemas/registration.yaml
+++ b/schemas/registration.yaml
@@ -1,0 +1,35 @@
+registration:
+  description: Registration initialization
+  type: object
+  x-examples:
+    example-1:
+      flow: 231125d7-11d5-4e0f-80e9-5081003ae8ca
+      properties:
+        id:
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
+
+registration-with-flow-id-request:
+  description: Registration with FlowID
+  type: object
+  required:
+    - method
+  method:
+    type: string
+    pattern: password
+
+registration-with-flow-id-response:
+  description: Registration with FlowID
+  type: object
+  required:
+    - accountKey
+  properties:
+    accountKey:
+      type: string
+      format: uuid
+      minLength: 36
+      maxLength: 36
+  example:
+    accountKey: 550e8400-e29b-11d4-a716-446655440000

--- a/schemas/user.yaml
+++ b/schemas/user.yaml
@@ -1,0 +1,33 @@
+user:
+  description: A user object
+  type: object
+  x-examples:
+    example-1:
+      user_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+      username: maja
+      role: user
+      example-2:
+        user_id: 123e4567-e89b-12d3-a456-426655440000
+        username: string
+        role: admin
+        x-tira: true
+        properties:
+          user_id:
+            type: string
+            format: uuid
+            minLength: 36
+            maxLength: 36
+            username:
+              type: string
+              minLength: 2
+              maxLength: 25
+              role:
+                type: string
+                minLength: 1
+                description: Refers to privileges.
+                enum:
+                  - admin
+                  - user
+                required:
+                  - user_id
+              

--- a/specs/authentication.yaml
+++ b/specs/authentication.yaml
@@ -1,0 +1,119 @@
+loginApiInit:
+  get:
+    description: This endpoint initiates a login flow for API clients that do not use a browser.
+    parameters:
+      - name: refresh
+        in: query
+        required: false
+        explode: true
+        schema:
+          type: boolean
+        style: form
+        description: |-
+          Refresh a login.
+
+          If set to true, this will refresh an existing login session by
+          asking the user to sign in again. This will reset the
+          authenticated_at time of the session.
+      - name: X-Session-Token
+        in: header
+        required: false
+        explode: false
+        schema: 
+          type: string
+        style: simple
+        description: The Session token of the Session performing the flow. Required when using the refresh parameter
+    responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '/schemas/kratos_t.yaml#/selfServiceLoginFlow'
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '/schemas/kratos_t.yaml#/jsonError'
+        "500":
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '/schemas/kratos_t.yaml#/jsonError'
+    x-accepts: application/json
+    tags:
+      - authentication
+### TPL RENDER {{ template "servers.tpl" "auth" }}
+    servers:
+      - url: https://auth.api.{environment}.mindtastic.lol
+        variables:
+          environment:
+            enum:
+              - live
+              - stage
+              - dev
+            default: live
+### END RENDER {{ template "servers.tpl" "auth" }}
+
+loginSubmit:
+  post:
+    parameters: 
+      - $ref: '/schemas/authentication.yaml#/flow'
+    responses:
+      "200":
+        description: "OK."
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/authentication.yaml#/session'
+      "303":
+        description: Returns the after login redirection url when a browser flow got submitted.
+      "400":
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/selfServiceLoginFlow'
+      "410":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/jsonError'
+      "422":
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/selfServiceBrowserLocationChangeRequiredError'
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/jsonError'
+    x-contentType: application/json
+    x-accepts: application/json
+    tags:
+      - authentication
+### TPL RENDER {{ template "servers.tpl" "auth" }}
+    servers:
+      - url: https://auth.api.{environment}.mindtastic.lol
+        variables:
+          environment:
+            enum:
+              - live
+              - stage
+              - dev
+            default: live
+### END RENDER {{ template "servers.tpl" "auth" }}
+
+  # /self-service/logout:
+  #   delete:
+  #     tags:
+  #       - authentication
+  #     responses:
+  #       '200':
+  #         description: OK
+  #       '500':
+  #         description: Internal Service Error              

--- a/specs/registration.yaml
+++ b/specs/registration.yaml
@@ -1,0 +1,105 @@
+registrationApiInit:
+  get:
+    summary: Initate registration flow
+    responses:
+      "200":
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/selfServiceRegistrationFlow'
+      "400":
+        description: Bad request
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/jsonError'
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/jsonError'
+    tags:
+      - authentication
+### TPL RENDER {{ template "servers.tpl" "auth" }}
+    servers:
+      - url: https://auth.api.{environment}.mindtastic.lol
+        variables:
+          environment:
+            enum:
+              - live
+              - stage
+              - dev
+            default: live
+### END RENDER {{ template "servers.tpl" "auth" }}
+registrationSubmit:
+  post:
+    summary: Complete registration flow
+    parameters:
+      - name: flow
+        in: query
+        required: true
+        explode: true
+        schema:
+          type: string
+        style: form
+        description: The Registration flow ID as an URL Query parameters
+      - name: Cookie
+        in: header
+        required: false
+        explode: false
+        schema:
+          type: string
+        style: simple
+        description: When using the browser flow, the HTTP cookie (encodes session and CSRF token) must be present
+    responses:
+      "200":
+        description: OK. Registration successful.
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/registration.yaml#/registration-with-flow-id-response'
+      "303":
+        description: Returns the after auto-login redirection url when a browser flow got submitted.
+      "400":
+        description: Bad requests. API returns a new or already created authflow.
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/selfServiceRegistrationFlow'
+      "410":
+        description: Gone. The appropriate auth flow expired before submitting.
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/jsonError'
+      "422":
+        description: The webbrowser is in a browser flow and needs to change its location before submitting.
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/selfServiceBrowserLocationChangeRequiredError'
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: '/schemas/kratos_t.yaml#/jsonError'
+
+
+    x-contentType: application/json
+    x-accepts: application/json
+    tags:
+      - authentication
+### TPL RENDER {{ template "servers.tpl" "auth" }}
+    servers:
+      - url: https://auth.api.{environment}.mindtastic.lol
+        variables:
+          environment:
+            enum:
+              - live
+              - stage
+              - dev
+            default: live
+### END RENDER {{ template "servers.tpl" "auth" }}

--- a/tpl/servers.tpl
+++ b/tpl/servers.tpl
@@ -1,0 +1,10 @@
+servers:
+  - url: {{- printf "https://%s.api.{environment}.mindtastic.lol" .Values.serviceName -}}
+    variables:
+      environment:
+        enum:
+          - live
+          - stage
+          - dev
+        default: live
+        description: Choose the environment to work on.


### PR DESCRIPTION
First of all: Please don't get afraid by the amount of changes this PR seems to bring. Actually, it does not change much. Mostly it dissects the API spec into more modular pieces, so we don't have a gigantic YAML file everybody has to work with. Moreover, this makes implementing *service ownership* much easier on the backend side.

Besides that, this PR introduces actual working service urls. OpenAPI basically forces you to have one single service url and then different endpoints. However, the cloud backend matches the requests to services by the Host Part of the URL (resp. SNI). Now, every open API path Item got the `servers` property, so you should be able to perform basic requests right from the API spec.

Also, the auth service specification is more detailed. Mostly copied from Kratos Doc. I will add more elaborate examples for our user case.

Last but not least, as we are now using multiple files, copying over the whole openapi.yaml file to swaggerhub (or any other editor) will fail. Therefore, I've activated GitHub Pages for the repository. For local testing, just start a simple http server in the directory and access swagger ui. Example using python:

```bash
python -m http.server

Serving HTTP on :: port 8000 (http://[::]:8000/) ...
# Now open http://localhost:8000 in your browser
```
